### PR TITLE
Fixing compatibility for 0.10.x versions of node

### DIFF
--- a/lib/git-ssh-server.js
+++ b/lib/git-ssh-server.js
@@ -1,4 +1,10 @@
 var fs         = require('fs');
+
+// version 0.10.x requires util-is for util.isString
+if(parseInt(process.version.split('.')[1]) === 10) {
+  require('util-is');
+}
+
 var util       = require('util');
 var crypto     = require('crypto');
 var path       = require('path');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-ssh-server",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "SSH server for handling git-{upload,receive}-pack with custom authorization",
   "main": "lib/git-ssh-server.js",
   "bin": {
@@ -30,6 +30,7 @@
     "handlebars" : "~2.0.0",
     "lockfile"   : "~1.0.0",
     "underscore" : "~1.6.0",
-    "docopt"     : "~0.4.0"
+    "docopt"     : "~0.4.0",
+    "util-is"    : "0.1.0"
   }
 }


### PR DESCRIPTION
util-is include is required for 0.10.x and breaks if included in 0.11.
Don't know exactly why, just conditionally including it depending on
node version.
